### PR TITLE
fix: update `exit status` when status != 0 on macOS

### DIFF
--- a/env/macsandbox/environment_darwin.go
+++ b/env/macsandbox/environment_darwin.go
@@ -106,6 +106,7 @@ func (e *environment) Execve(c context.Context, param envexec.ExecveParam) (enve
 			case wstatus.Exited():
 				if status := wstatus.ExitStatus(); status != 0 {
 					p.result.Status = runner.StatusNonzeroExitStatus
+					p.result.ExitStatus = status
 					return
 				}
 				return


### PR DESCRIPTION
When a process exits on macOS with a non-zero status, its exit status is left unfilled.
<img width="506" alt="Screen Shot 2023-06-11 at 3 56 59 PM" src="https://github.com/criyle/go-judge/assets/31000844/5fea98c9-55cc-48d7-b1c9-63443eb78f91">
