### PR TITLE
fix: remove empty copyOut

### DIFF
--- a/cmd/go-judge-shell/grpc.go
+++ b/cmd/go-judge-shell/grpc.go
@@ -181,7 +181,7 @@ func convertPBCopyIn(copyIn map[string]model.CmdFile) map[string]*pb.Request_Fil
 }
 
 func convertPBCopyOut(copyOut []string) []*pb.Request_CmdCopyOutFile {
-	rt := make([]*pb.Request_CmdCopyOutFile, len(copyOut))
+	rt := make([]*pb.Request_CmdCopyOutFile, 0)
 	for _, n := range copyOut {
 		optional := false
 		if strings.HasSuffix(n, "?") {

--- a/cmd/go-judge-shell/grpc.go
+++ b/cmd/go-judge-shell/grpc.go
@@ -181,7 +181,7 @@ func convertPBCopyIn(copyIn map[string]model.CmdFile) map[string]*pb.Request_Fil
 }
 
 func convertPBCopyOut(copyOut []string) []*pb.Request_CmdCopyOutFile {
-	rt := make([]*pb.Request_CmdCopyOutFile, 0)
+	rt := make([]*pb.Request_CmdCopyOutFile, 0, len(copyOut))
 	for _, n := range copyOut {
 		optional := false
 		if strings.HasSuffix(n, "?") {


### PR DESCRIPTION
Since `append` is used for each `copyOut`, we do not need to preserve space in `make`.