### PR TITLE
refactor(rest_executor): rename handlers and clean up routing logic

### DIFF
--- a/cmd/go-judge/main.go
+++ b/cmd/go-judge/main.go
@@ -317,8 +317,10 @@ func initHTTPMux(conf *config.Config, work worker.Worker, fs filestore.FileStore
 	}
 
 	// Rest Handle
-	restHandle := restexecutor.New(work, fs, conf.SrcPrefix, logger)
-	restHandle.Register(r)
+	cmdHandle := restexecutor.NewCmdHandle(work, conf.SrcPrefix, logger)
+	cmdHandle.Register(r)
+	fileHandle := restexecutor.NewFileHandle(fs)
+	fileHandle.Register(r)
 
 	// WebSocket Handle
 	wsHandle := wsexecutor.New(work, conf.SrcPrefix, logger)

--- a/cmd/go-judge/register/register.go
+++ b/cmd/go-judge/register/register.go
@@ -1,0 +1,8 @@
+package register
+
+import "github.com/gin-gonic/gin"
+
+// Register registers executor the handler
+type Register interface {
+	Register(*gin.Engine)
+}

--- a/cmd/go-judge/rest_executor/cmd_handler.go
+++ b/cmd/go-judge/rest_executor/cmd_handler.go
@@ -6,81 +6,72 @@ import (
 	"net/http"
 
 	"github.com/criyle/go-judge/cmd/go-judge/model"
-	"github.com/criyle/go-judge/filestore"
 	"github.com/criyle/go-judge/worker"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
-// New creates new REST API handler
-func New(worker worker.Worker, fs filestore.FileStore, srcPrefix []string, logger *zap.Logger) register.Register {
-	return &handle{
-		worker:     worker,
-		fileHandle: fileHandle{fs: fs},
-		srcPrefix:  srcPrefix,
-		logger:     logger,
-	}
-}
-
-type handle struct {
-	worker worker.Worker
-	fileHandle
+type cmdHandle struct {
+	worker    worker.Worker
 	srcPrefix []string
 	logger    *zap.Logger
 }
 
-func (h *handle) Register(r *gin.Engine) {
-	// Run handle
-	r.POST("/run", h.handleRun)
-
-	// File handle
-	r.GET("/file", h.fileGet)
-	r.POST("/file", h.filePost)
-	r.GET("/file/:fid", h.fileIDGet)
-	r.DELETE("/file/:fid", h.fileIDDelete)
+// NewCmdHandle creates a new command handle
+func NewCmdHandle(worker worker.Worker, srcPrefix []string, logger *zap.Logger) register.Register {
+	return &cmdHandle{
+		worker:    worker,
+		srcPrefix: srcPrefix,
+		logger:    logger,
+	}
 }
 
-func (h *handle) handleRun(c *gin.Context) {
+func (c *cmdHandle) Register(r *gin.Engine) {
+	// Run handle
+	r.POST("/run", c.handleRun)
+}
+
+func (c *cmdHandle) handleRun(ctx *gin.Context) {
 	var req model.Request
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.Error(err)
-		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.Error(err)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 		return
 	}
 
 	if len(req.Cmd) == 0 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, "no cmd provided")
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, "no cmd provided")
 		return
 	}
-	r, err := model.ConvertRequest(&req, h.srcPrefix)
+	r, err := model.ConvertRequest(&req, c.srcPrefix)
 	if err != nil {
-		c.Error(err)
-		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		ctx.Error(err)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 		return
 	}
-	h.logger.Sugar().Debugf("request: %+v", r)
-	rtCh, _ := h.worker.Submit(c.Request.Context(), r)
+	c.logger.Sugar().Debugf("request: %+v", r)
+	rtCh, _ := c.worker.Submit(ctx.Request.Context(), r)
 	rt := <-rtCh
-	h.logger.Sugar().Debugf("response: %+v", rt)
+	c.logger.Sugar().Debugf("response: %+v", rt)
 	if rt.Error != nil {
-		c.Error(rt.Error)
-		c.AbortWithStatusJSON(http.StatusInternalServerError, rt.Error.Error())
+		ctx.Error(rt.Error)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, rt.Error.Error())
 		return
 	}
 
 	// encode json directly to avoid allocation
-	c.Status(http.StatusOK)
-	c.Header("Content-Type", "application/json; charset=utf-8")
+	ctx.Status(http.StatusOK)
+	ctx.Header("Content-Type", "application/json; charset=utf-8")
 
 	res, err := model.ConvertResponse(rt, true)
 	if err != nil {
-		c.Error(err)
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		ctx.Error(err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
 	}
 	defer res.Close()
 
-	if err := json.NewEncoder(c.Writer).Encode(res.Results); err != nil {
-		c.Error(err)
+	if err := json.NewEncoder(ctx.Writer).Encode(res.Results); err != nil {
+		ctx.Error(err)
 	}
 }

--- a/cmd/go-judge/rest_executor/cmd_handler.go
+++ b/cmd/go-judge/rest_executor/cmd_handler.go
@@ -2,6 +2,7 @@ package restexecutor
 
 import (
 	"encoding/json"
+	"github.com/criyle/go-judge/cmd/go-judge/register"
 	"net/http"
 
 	"github.com/criyle/go-judge/cmd/go-judge/model"
@@ -11,15 +12,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Register registers executor the handler
-//
-// POST /run, GET /file, POST /file, GET /file/:fid, DELETE /file/:fid
-type Register interface {
-	Register(*gin.Engine)
-}
-
 // New creates new REST API handler
-func New(worker worker.Worker, fs filestore.FileStore, srcPrefix []string, logger *zap.Logger) Register {
+func New(worker worker.Worker, fs filestore.FileStore, srcPrefix []string, logger *zap.Logger) register.Register {
 	return &handle{
 		worker:     worker,
 		fileHandle: fileHandle{fs: fs},

--- a/cmd/go-judge/rest_executor/cmd_handler.go
+++ b/cmd/go-judge/rest_executor/cmd_handler.go
@@ -2,7 +2,6 @@ package restexecutor
 
 import (
 	"encoding/json"
-	"github.com/criyle/go-judge/cmd/go-judge/register"
 	"net/http"
 
 	"github.com/criyle/go-judge/cmd/go-judge/model"
@@ -18,7 +17,7 @@ type cmdHandle struct {
 }
 
 // NewCmdHandle creates a new command handle
-func NewCmdHandle(worker worker.Worker, srcPrefix []string, logger *zap.Logger) register.Register {
+func NewCmdHandle(worker worker.Worker, srcPrefix []string, logger *zap.Logger) Register {
 	return &cmdHandle{
 		worker:    worker,
 		srcPrefix: srcPrefix,

--- a/cmd/go-judge/rest_executor/file_handler.go
+++ b/cmd/go-judge/rest_executor/file_handler.go
@@ -2,7 +2,6 @@ package restexecutor
 
 import (
 	"fmt"
-	"github.com/criyle/go-judge/cmd/go-judge/register"
 	"io"
 	"mime"
 	"net/http"
@@ -18,7 +17,7 @@ type fileHandle struct {
 }
 
 // NewFileHandle creates a new file handle
-func NewFileHandle(fs filestore.FileStore) register.Register {
+func NewFileHandle(fs filestore.FileStore) Register {
 	return &fileHandle{
 		fs: fs,
 	}

--- a/cmd/go-judge/rest_executor/file_handler.go
+++ b/cmd/go-judge/rest_executor/file_handler.go
@@ -2,6 +2,7 @@ package restexecutor
 
 import (
 	"fmt"
+	"github.com/criyle/go-judge/cmd/go-judge/register"
 	"io"
 	"mime"
 	"net/http"
@@ -14,6 +15,21 @@ import (
 
 type fileHandle struct {
 	fs filestore.FileStore
+}
+
+// NewFileHandle creates a new file handle
+func NewFileHandle(fs filestore.FileStore) register.Register {
+	return &fileHandle{
+		fs: fs,
+	}
+}
+
+func (f *fileHandle) Register(r *gin.Engine) {
+	// File handle
+	r.GET("/file", f.fileGet)
+	r.POST("/file", f.filePost)
+	r.GET("/file/:fid", f.fileIDGet)
+	r.DELETE("/file/:fid", f.fileIDDelete)
 }
 
 func (f *fileHandle) fileGet(c *gin.Context) {

--- a/cmd/go-judge/rest_executor/register.go
+++ b/cmd/go-judge/rest_executor/register.go
@@ -1,4 +1,4 @@
-package register
+package restexecutor
 
 import "github.com/gin-gonic/gin"
 


### PR DESCRIPTION
- Rename `handle` to `CmdHandler`
- Rename `fileHandle` to `FileHandler`
- Remove unnecessary `Register` interface
- Move routing logic to `router.go`